### PR TITLE
fixed request body to array type godaddy is expecting

### DIFF
--- a/godaddy_ddns.ps1
+++ b/godaddy_ddns.ps1
@@ -23,7 +23,7 @@ $dnsIp = $content.data
 $currentIp = Invoke-RestMethod http://ipinfo.io/json | Select -exp ip
 
 if ( $currentIp -ne $dnsIp) {
-    $Request = @{ttl=3600;data=$currentIp }
+    $Request = @(@{ttl=3600;data=$currentIp; })
     $JSON = Convertto-Json $request
     Invoke-WebRequest https://api.godaddy.com/v1/domains/$domain/records/A/$name -method put -headers $headers -Body $json -ContentType "application/json"
 }


### PR DESCRIPTION
otherwise, Godaddy returns an error like this:
Invoke-WebRequest : {"code":"INVALID_BODY","fields":[{"code":"UNEXPECTED_TYPE","message":"is not a 
array","path":"records"}],"message":"Request body doesn't fulfill schema, see details in `fields`"}