### PR TITLE
Shell script request fix

### DIFF
--- a/GoDaddy_Bash_DDNS.sh
+++ b/GoDaddy_Bash_DDNS.sh
@@ -35,7 +35,7 @@ if [ "$dnsIpa" = "$currentIp" ];
 # if [[ "$dnsIp" =! "$currentIp" ]];
  then
 #       echo "Ips are not equal"
-        request='{"data":"'$currentIp'","ttl":3600}'
+        request='[{"data":"'$currentIp'","ttl":3600}]'
 #       echo $request
         nresult=$(curl -i -s -X PUT \
  -H "$headers" \


### PR DESCRIPTION
I changed the $request object in the shell script from containing the object `{"data":"'$currentIp'","ttl":3600}` to containing an array with one member which is the aformentioned object:  `[{"data":"'$currentIp'","ttl":3600}]`  
This has been done to comply with the [godaddy API](https://developer.godaddy.com/doc/endpoint/domains#/v1/recordReplace) and is a change analogous to fcb249059097282c189fc846f8222c9012855d97.