### PR TITLE
change to https; fixes response returning incorrect IP using http

### DIFF
--- a/godaddy_ddns.ps1
+++ b/godaddy_ddns.ps1
@@ -20,7 +20,7 @@ $content = ConvertFrom-Json $result.content
 $dnsIp = $content.data
 
 # Get public ip address there are several websites that can do this.
-$currentIp = Invoke-RestMethod http://ipinfo.io/json | Select-Object -ExpandProperty ip
+$currentIp = Invoke-RestMethod https://ipinfo.io/json | Select-Object -ExpandProperty ip
 
 if ( $currentIp -ne $dnsIp) {
     $Request = @(@{ttl=3600;data=$currentIp; })


### PR DESCRIPTION
I'm not sure if this started happening recently, but I get an incorrect IP response from http://ipinfo.io/json . Switching to HTTPS fixes the problem for me.