### PR TITLE
Only fetch first IP coming from ipinfo

### DIFF
--- a/GoDaddy_Bash_DDNS.sh
+++ b/GoDaddy_Bash_DDNS.sh
@@ -31,8 +31,7 @@ dnsIp=$(echo $result | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")
 
 # Get public ip address there are several websites that can do this.
 ret=$(curl -s GET "http://ipinfo.io/json")
-currentIp=$(echo $ret | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")
-
+currentIp=$(echo $ret | grep -oE -m 1 "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b" | head -1)
 
 #echo "currentIp:" $currentIp
 


### PR DESCRIPTION
ipinfo.io can return ips in the host name section such as this:


ip | "152.0.121.242"
-- | --
hostname | "242.125.0.151.d.dyn.claro.net.do"
... | ...

This causes the $currentIp variable to be set with invalid data.

This PR makes it so that the grep command only returns the the first IP returned ipinfo and uses it to set $currentIp.